### PR TITLE
Adds small caps when available to caps utility

### DIFF
--- a/index.css
+++ b/index.css
@@ -3,7 +3,11 @@
 .bold    { font-weight: var(--bold-font-weight, bold) }
 .regular { font-weight: normal }
 .italic  { font-style: italic }
-.caps    { text-transform: uppercase; letter-spacing: .2em; }
+.caps {
+  text-transform: uppercase;
+  letter-spacing: .2em;
+  font-feature-settings: "kern" 1, "liga" 1, "calt" 1, "pnum" 1, "tnum" 0, "onum" 1, "lnum" 0, "smcp" 1, "c2sc" 1;
+}
 
 .left-align   { text-align: left }
 .center       { text-align: center }
@@ -24,4 +28,3 @@
   list-style: none;
   padding-left: 0;
 }
-


### PR DESCRIPTION
Hey! Been keeping tabs on Basscss, really nice work.

I’ve just added small caps to the caps utility here, based on what I have [in Normalize-OpenType.css](https://github.com/kennethormandy/normalize-opentype.css/blob/master/normalize-opentype.scss#L39-L47). When a typeface has small caps included, it will use them now, and if not the existing behaviour will be used.

I decided to line break them, but I can fix that if you’d still prefer everything to be on one line.

Sorry if you already know all this stuff, but just to give a little more detail on that whole string of `font-feature-settings`:

- `kern` turns on kerning
- `liga` turns on basic ligatures
- `calt` turns on contextual alternates, usually for script typefaces
- `pnum` is on and `tnum` is off, using proportional numerals instead of tabular
- `onum` is on and `lnum` is off, using old style numerals which will properly match the x-height of the small caps
- `smcp` turns on small caps
- `c2sc` turns on caps to small caps, so that you can still fallback to `text-transform: uppercase` for web fonts without small caps included

__Edit__ Also I’m assuming that this gets Autoprefixed at some point, I didn’t actually find where that is happening.